### PR TITLE
Fix test assertion

### DIFF
--- a/packages/e2e-tests/specs/example.spec.ts
+++ b/packages/e2e-tests/specs/example.spec.ts
@@ -45,6 +45,6 @@ describe( 'Shortcode', () => {
 		// Check if the shortcode is applied correctly.
 		const [ link ] = await page.$x( "//a[contains(., 'Learn React')]" );
 
-		expect( link ).not.toBeNull();
+		expect( link ).not.toBeUndefined();
 	} );
 } );


### PR DESCRIPTION
`not.toBeNull()` doesn't throw an error when the element doesn't exist.