### PR TITLE
chore: ignore wp-deps.

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,4 +1,4 @@
 /vendor
 /build
-*.min.js
+*.min.css
 /wp-deps


### PR DESCRIPTION
Without this, lints are trying to lint files in wp-deps.